### PR TITLE
user variables to be sent in sandbox as "key=value" pairs

### DIFF
--- a/phpsandbox.php
+++ b/phpsandbox.php
@@ -290,8 +290,8 @@ class PHPSandbox {
 		$string .= ' _END';
 			
 		if(isset($pass_through_vars) and count($pass_through_vars) > 0){
-			foreach ($pass_through_vars as $value){
-				$string .= ' '.$value;
+			foreach ($pass_through_vars as $key => $value){
+				$string .= ' '.$key."=".$value;
 			}
 		}
 		


### PR DESCRIPTION
added user variables as key=value,
that way the argv can be loop through and find each element and define them globally. Something like follows: 

```
php run.php _POST={...} ... abc=xyz
```

In run.php

```
foreach($argv as $index => $value) {
   $elems = explode("=", $value);
   $len = strlen($elems[0]);
   switch($elems[0]) {
       case '_POST':
           $_POST = unserialize(substr($value, $len+1));
       break;
       default:
           $$key = unserialize(substr($value, $len+1));
       break;
   }
}
```

so that will create variable called $abc with value "xyz"
